### PR TITLE
Feature  oop generation

### DIFF
--- a/nsl_data_utils/misc/generate.py
+++ b/nsl_data_utils/misc/generate.py
@@ -10,32 +10,17 @@ from nsl_data_utils.misc.generators import MultilayerERGenerator, MultilayerPAGe
 from tqdm.contrib.concurrent import process_map
 
 
-def generate_and_save(
-    model_type: str,
-    actors: int,
-    layers: int,
-    steps: int,
-    outfile: str,
-    random_state: int | None = None,
-) -> None:
+def generate_and_save(model_type: str, actors: int, layers: int, steps: int, outfile: str) -> None:
     """Generate network and save it as an mpx file."""
     if model_type == "PA":
         nb_hubs = int(max(3, 0.05 * actors))
         generator = MultilayerPAGenerator(
-            nb_layers=layers,
-            nb_actors=actors,
-            nb_steps=steps,
-            nb_hubs=nb_hubs,
-            random_state=random_state,
+            nb_layers=layers, nb_actors=actors, nb_steps=steps, nb_hubs=nb_hubs
         )
     elif model_type == "ER":
         std_nodes = int(0.1 * actors)
         generator = MultilayerERGenerator(
-            nb_layers=layers,
-            nb_actors=actors,
-            nb_steps=steps,
-            std_nodes=std_nodes,
-            random_state=random_state,
+            nb_layers=layers, nb_actors=actors, nb_steps=steps, std_nodes=std_nodes
         )
     else:
         raise ValueError("Model type can be either PA or ER!")
@@ -55,7 +40,6 @@ def parse_args(args=None) -> Namespace:
     parser.add_argument("min_layers", type=int)
     parser.add_argument("max_layers", type=int)
     parser.add_argument("model_type", type=str, choices=["ER", "PA"])
-    parser.add_argument("--random-state", type=int, default=None)
     parser.add_argument("-o", "--output-dir", type=str, default="./generated_graphs/")
     parser.add_argument("--n-jobs", type=int, default=1)
     parser.add_argument("--chunksize", type=int, default=1)
@@ -64,20 +48,12 @@ def parse_args(args=None) -> Namespace:
 
 def main(args: Namespace) -> None:
     """Main generation routine feed with CLI args."""
-
-    if args.random_state is not None:
-        np.random.seed(args.random_state)  # TODO!!!
-
     actors = np.random.randint(args.min_actors, args.max_actors + 1, dtype=np.int32, size=args.nb_networks)
     layers = np.random.randint(args.min_layers, args.max_layers + 1, dtype=np.int32, size=args.nb_networks)
     steps = actors * 5
     output_dir = Path(args.output_dir)
     output_dir.mkdir(exist_ok=True, parents=True)
     outfiles = (output_dir / f"network_{idx}.mpx" for idx, _ in enumerate(actors, 1))
-    random_states = (
-        np.random.random(size=len(actors)) * 10 ** (np.log10(len(actors)) + 1)
-    ).astype(np.int32)
-
     process_map(
         generate_and_save,
         [args.model_type] * len(actors),
@@ -85,7 +61,6 @@ def main(args: Namespace) -> None:
         layers,
         steps,
         outfiles,
-        random_states,
         max_workers=args.n_jobs,
         chunksize=args.chunksize,
     )
@@ -101,9 +76,8 @@ def cli():
             "5",
             "ER",
             "--output-dir", "/Users/michal/Development/infmax-trainer-icm-mln/krakrarkarka",
-            "--n-jobs", "10",
-            "--chunksize", "1",
-            "--random-state", "1",
+            "--n-jobs", "5",
+            "--chunksize", "20"
         ]
     )
     print(args)

--- a/nsl_data_utils/misc/generate.py
+++ b/nsl_data_utils/misc/generate.py
@@ -1,17 +1,15 @@
-"""
-Generate a multilayer network
-"""
+"""Generate multilayer networks with Preferential Attachment or Erdos-Renyi models."""
+
 import abc
 
 from argparse import ArgumentParser, Namespace, RawDescriptionHelpFormatter
 from pathlib import Path
-from typing import Any, Callable
 
 import numpy as np
 import uunet.multinet as ml
+
 from tqdm.contrib.concurrent import process_map
 from uunet._multinet import PyMLNetwork, PyEvolutionModel
-
 
 
 class MultilayerBaseGenerator(abc.ABC):
@@ -76,7 +74,14 @@ class MultilayerBaseGenerator(abc.ABC):
 class MultilayerERGenerator(MultilayerBaseGenerator):
     """Class which generates multilayer network with Erdos-Renyi algorithm."""
     
-    def __init__(self, nb_layers: int, nb_actors: int, nb_steps: int, std_nodes: int, random_state: int | None = None) -> None:
+    def __init__(
+        self,
+        nb_layers: int,
+        nb_actors: int,
+        nb_steps: int,
+        std_nodes: int,
+        random_state: int | None = None
+    ) -> None:
         """
         Initialise the object.
 
@@ -98,7 +103,7 @@ class MultilayerERGenerator(MultilayerBaseGenerator):
 
     def get_models(self) -> list[PyEvolutionModel]:
         """
-        Get evolutionary models for each layer.
+        Get evolutionary models for each layer with num nodes drawn from a standard distribution.
 
         :return: list of Erdos-Renyi generators
         """
@@ -111,15 +116,21 @@ class MultilayerERGenerator(MultilayerBaseGenerator):
 class MultilayerPAGenerator(MultilayerBaseGenerator):
     """Class which generates multilayer network with Preferential Attachment algorithm."""
     
-    def __init__(self, nb_layers: int, nb_actors: int, nb_steps: int, nb_hubs: int, random_state: int | None = None) -> None:
+    def __init__(
+        self,
+        nb_layers: int,
+        nb_actors: int,
+        nb_steps: int,
+        nb_hubs: int,
+        random_state: int | None = None
+    ) -> None:
         """
         Initialise the object.
 
         :param nb_layers: number of layers of the generated network
         :param nb_actors: number of actors in the network
         :param nb_steps: number of steps of the generative algorithm which builds the network
-        :param std_nodes: standard deviation of the number of nodes in each layer (expected value
-            is a number of actors)
+        :param nb_seeds: number of seeds in each layer and a number of egdes from each new vertex
         :param random_state: RNG state to make the generation reproducible, defaults to None
         """
         super().__init__(
@@ -232,7 +243,6 @@ def main(args: Namespace):
 
 
 def cli():
-    import network_diffusion as nd
     args = parse_args(
         [
             "100",
@@ -245,13 +255,35 @@ def cli():
         ]
     )
     # main(args)
-    net_uu = MultilayerERGenerator(nb_layers=3, nb_actors=30, nb_steps=40, std_nodes=14, random_state=43)()
-    # ml.plot(n=net_uu)
+
+
+def dry_run() -> None:
+    import matplotlib.pyplot as plt
+    import networkx as nx
+    import network_diffusion as nd
+
+    net_uu = MultilayerERGenerator(
+        nb_layers=3, nb_actors=300, nb_steps=400, std_nodes=30, random_state=43
+    )()
+    # net_uu = MultilayerPAGenerator(
+    #     nb_layers=3, nb_actors=1000, nb_steps=1000, nb_hubs=3, random_state=43
+    # )()
+    print(net_uu)
+
     net_nx = ml.to_nx_dict(net_uu)
+    print(net_nx)
+
     net_nd = nd.MultilayerNetwork(layers=net_nx)
-    nd.mln.functions.draw_mln(net_nd)
-    # print(network)
+    print(net_nd)
+
+    fig, axs = plt.subplots(nrows=1, ncols=len(net_nx))
+    for l_idx, (l_name, l_graph) in enumerate(net_nx.items()):
+        axs[l_idx].hist(nx.degree_histogram(l_graph), bins=10)
+        axs[l_idx].set_title(l_name)
+    fig.suptitle("Degree distribution")
+    plt.show()
 
 
 if __name__ == "__main__":
-    cli()
+    dry_run()
+    # cli()

--- a/nsl_data_utils/misc/generate.py
+++ b/nsl_data_utils/misc/generate.py
@@ -1,6 +1,4 @@
-"""Generate multilayer networks with Preferential Attachment or Erdos-Renyi models."""
-
-import abc
+"""Generate multilayer networks with predefined network models."""
 
 from argparse import ArgumentParser, Namespace, RawDescriptionHelpFormatter
 from pathlib import Path
@@ -8,148 +6,9 @@ from pathlib import Path
 import numpy as np
 import uunet.multinet as ml
 
+from nsl_data_utils.misc.generators import MultilayerERGenerator, MultilayerPAGenerator
 from tqdm.contrib.concurrent import process_map
-from uunet._multinet import PyMLNetwork, PyEvolutionModel
-
-
-class MultilayerBaseGenerator(abc.ABC):
-    """Abstract base class for multilayer network generators."""
-
-    @abc.abstractmethod
-    def __init__(
-        self, nb_layers: int, nb_actors: int, nb_steps: int, random_state: int | None = None,
-    ) -> None:
-        """
-        Initialise the object.
-
-        :param nb_layers: number of layers of the generated network
-        :param nb_actors: number of actors in the network
-        :param nb_steps: number of steps of the generative algorithm which builds the network
-        :param random_state: RNG state to make the generation reproducible, defaults to None
-        """
-        self.nb_layers=nb_layers
-        self.nb_actors=nb_actors
-        self.nb_steps=nb_steps
-        self.rng = np.random.default_rng(random_state)
-
-    @abc.abstractmethod
-    def get_models(self) -> list[PyEvolutionModel]:
-        """
-        Get evolutionary models for each layer.
-
-        :return: list of concrete network generators
-        """
-        pass
-
-    def get_dependency(self) -> np.ndarray:
-        """
-        Create a dependency matrix for the network generator.
-
-        :return: matrix shaped: [nb_layers, nb_layers] with 0s in diagonal and 1/nb_layers otherwise
-        """
-        dep = np.full(fill_value=(1 / self.nb_layers), shape=(self.nb_layers, self.nb_layers))
-        np.fill_diagonal(dep, 0)
-        return dep
-
-    def __call__(self) -> PyMLNetwork:
-        """
-        Generate the network according to given parameters.
-
-        :return: generated network as a PyEvolutionModel object
-        """
-        models = self.get_models()
-        pr_internal = self.rng.uniform(0, 1, size=self.nb_layers)
-        pr_external = np.ones_like(pr_internal) - pr_internal  # TODO: there is no noaction step now!
-        dependency = self.get_dependency()
-        return ml.grow(
-            self.nb_actors,
-            self.nb_steps,
-            models,
-            pr_internal.tolist(),
-            pr_external.tolist(),
-            dependency.tolist(),
-        )
-
-
-class MultilayerERGenerator(MultilayerBaseGenerator):
-    """Class which generates multilayer network with Erdos-Renyi algorithm."""
-    
-    def __init__(
-        self,
-        nb_layers: int,
-        nb_actors: int,
-        nb_steps: int,
-        std_nodes: int,
-        random_state: int | None = None
-    ) -> None:
-        """
-        Initialise the object.
-
-        :param nb_layers: number of layers of the generated network
-        :param nb_actors: number of actors in the network
-        :param nb_steps: number of steps of the generative algorithm which builds the network
-        :param std_nodes: standard deviation of the number of nodes in each layer (expected value
-            is a number of actors)
-        :param random_state: RNG state to make the generation reproducible, defaults to None
-        """
-        super().__init__(
-            nb_layers=nb_layers,
-            nb_actors=nb_actors,
-            nb_steps=nb_steps,
-            random_state=random_state
-        )
-        assert nb_actors - 2 * std_nodes > 0, "Number of actors shall be g.t. 2 * std_nodes"
-        self.std_nodes=std_nodes
-
-    def get_models(self) -> list[PyEvolutionModel]:
-        """
-        Get evolutionary models for each layer with num nodes drawn from a standard distribution.
-
-        :return: list of Erdos-Renyi generators
-        """
-        layer_sizes = self.rng.normal(
-            loc=self.nb_actors - self.std_nodes, scale=self.std_nodes, size=self.nb_layers
-        ).astype(int).clip(min=1, max=self.nb_actors)
-        return [ml.evolution_er(n=lv) for lv in layer_sizes]
-
-
-class MultilayerPAGenerator(MultilayerBaseGenerator):
-    """Class which generates multilayer network with Preferential Attachment algorithm."""
-    
-    def __init__(
-        self,
-        nb_layers: int,
-        nb_actors: int,
-        nb_steps: int,
-        nb_hubs: int,
-        random_state: int | None = None
-    ) -> None:
-        """
-        Initialise the object.
-
-        :param nb_layers: number of layers of the generated network
-        :param nb_actors: number of actors in the network
-        :param nb_steps: number of steps of the generative algorithm which builds the network
-        :param nb_seeds: number of seeds in each layer and a number of egdes from each new vertex
-        :param random_state: RNG state to make the generation reproducible, defaults to None
-        """
-        super().__init__(
-            nb_layers=nb_layers,
-            nb_actors=nb_actors,
-            nb_steps=nb_steps,
-            random_state=random_state
-        )
-        self.nb_hubs = nb_hubs
-
-    def get_models(self) -> list[PyEvolutionModel]:
-        """
-        Get evolutionary models for each layer.
-
-        :return: list of Preferential Attachment generators
-        """
-        m0s = [self.nb_hubs] * self.nb_layers
-        ms = m0s.copy()
-        return [ml.evolution_pa(m0=m0, m=ms) for m0, ms in zip(m0s, ms)]
+from uunet._multinet import PyMLNetwork
 
 
 def generate_multilayer(
@@ -188,27 +47,22 @@ def save_generate(
 
 
 def parse_args(args=None) -> Namespace:
+    """Parse CLI args accorfding to the parser."""
     parser = ArgumentParser(
         description=__doc__,
         formatter_class=RawDescriptionHelpFormatter,
     )
     parser.add_argument("min_actors", type=int)
     parser.add_argument("max_actors", type=int)
-
     parser.add_argument("-s", "--step-size", type=int, default=1)
-    parser.add_argument(
-        "-o", "--output-dir", type=str, default="./generated_graphs/"
-    )
-
+    parser.add_argument("-o", "--output-dir", type=str, default="./generated_graphs/")
     parser.add_argument("--n-jobs", type=int, default=None)
     parser.add_argument("--chunksize", type=int, default=1)
     parser.add_argument("--random-state", type=int, default=None)
-
     return parser.parse_args(args)
 
 
-def main(args: Namespace):
-    print(args)
+def main(args: Namespace) -> None:
     rng = np.random.default_rng(args.random_state)
 
     actors = np.arange(args.min_actors, args.max_actors, args.step_size, dtype=np.int32)
@@ -254,36 +108,9 @@ def cli():
             "--random-state", "1",
         ]
     )
-    # main(args)
-
-
-def dry_run() -> None:
-    import matplotlib.pyplot as plt
-    import networkx as nx
-    import network_diffusion as nd
-
-    net_uu = MultilayerERGenerator(
-        nb_layers=3, nb_actors=300, nb_steps=400, std_nodes=30, random_state=43
-    )()
-    # net_uu = MultilayerPAGenerator(
-    #     nb_layers=3, nb_actors=1000, nb_steps=1000, nb_hubs=3, random_state=43
-    # )()
-    print(net_uu)
-
-    net_nx = ml.to_nx_dict(net_uu)
-    print(net_nx)
-
-    net_nd = nd.MultilayerNetwork(layers=net_nx)
-    print(net_nd)
-
-    fig, axs = plt.subplots(nrows=1, ncols=len(net_nx))
-    for l_idx, (l_name, l_graph) in enumerate(net_nx.items()):
-        axs[l_idx].hist(nx.degree_histogram(l_graph), bins=10)
-        axs[l_idx].set_title(l_name)
-    fig.suptitle("Degree distribution")
-    plt.show()
+    print(args)
+    main(args)
 
 
 if __name__ == "__main__":
-    dry_run()
-    # cli()
+    cli()

--- a/nsl_data_utils/misc/generate.py
+++ b/nsl_data_utils/misc/generate.py
@@ -1,14 +1,144 @@
 """
 Generate a multilayer network
 """
+import abc
 
 from argparse import ArgumentParser, Namespace, RawDescriptionHelpFormatter
 from pathlib import Path
+from typing import Any, Callable
 
 import numpy as np
 import uunet.multinet as ml
 from tqdm.contrib.concurrent import process_map
-from uunet._multinet import PyMLNetwork
+from uunet._multinet import PyMLNetwork, PyEvolutionModel
+
+
+
+class MultilayerBaseGenerator(abc.ABC):
+    """Abstract base class for multilayer network generators."""
+
+    @abc.abstractmethod
+    def __init__(
+        self, nb_layers: int, nb_actors: int, nb_steps: int, random_state: int | None = None,
+    ) -> None:
+        """
+        Initialise the object.
+
+        :param nb_layers: number of layers of the generated network
+        :param nb_actors: number of actors in the network
+        :param nb_steps: number of steps of the generative algorithm which builds the network
+        :param random_state: RNG state to make the generation reproducible, defaults to None
+        """
+        self.nb_layers=nb_layers
+        self.nb_actors=nb_actors
+        self.nb_steps=nb_steps
+        self.rng = np.random.default_rng(random_state)
+
+    @abc.abstractmethod
+    def get_models(self) -> list[PyEvolutionModel]:
+        """
+        Get evolutionary models for each layer.
+
+        :return: list of concrete network generators
+        """
+        pass
+
+    def get_dependency(self) -> np.ndarray:
+        """
+        Create a dependency matrix for the network generator.
+
+        :return: matrix shaped: [nb_layers, nb_layers] with 0s in diagonal and 1/nb_layers otherwise
+        """
+        dep = np.full(fill_value=(1 / self.nb_layers), shape=(self.nb_layers, self.nb_layers))
+        np.fill_diagonal(dep, 0)
+        return dep
+
+    def __call__(self) -> PyMLNetwork:
+        """
+        Generate the network according to given parameters.
+
+        :return: generated network as a PyEvolutionModel object
+        """
+        models = self.get_models()
+        pr_internal = self.rng.uniform(0, 1, size=self.nb_layers)
+        pr_external = np.ones_like(pr_internal) - pr_internal  # TODO: there is no noaction step now!
+        dependency = self.get_dependency()
+        return ml.grow(
+            self.nb_actors,
+            self.nb_steps,
+            models,
+            pr_internal.tolist(),
+            pr_external.tolist(),
+            dependency.tolist(),
+        )
+
+
+class MultilayerERGenerator(MultilayerBaseGenerator):
+    """Class which generates multilayer network with Erdos-Renyi algorithm."""
+    
+    def __init__(self, nb_layers: int, nb_actors: int, nb_steps: int, std_nodes: int, random_state: int | None = None) -> None:
+        """
+        Initialise the object.
+
+        :param nb_layers: number of layers of the generated network
+        :param nb_actors: number of actors in the network
+        :param nb_steps: number of steps of the generative algorithm which builds the network
+        :param std_nodes: standard deviation of the number of nodes in each layer (expected value
+            is a number of actors)
+        :param random_state: RNG state to make the generation reproducible, defaults to None
+        """
+        super().__init__(
+            nb_layers=nb_layers,
+            nb_actors=nb_actors,
+            nb_steps=nb_steps,
+            random_state=random_state
+        )
+        assert nb_actors - 2 * std_nodes > 0, "Number of actors shall be g.t. 2 * std_nodes"
+        self.std_nodes=std_nodes
+
+    def get_models(self) -> list[PyEvolutionModel]:
+        """
+        Get evolutionary models for each layer.
+
+        :return: list of Erdos-Renyi generators
+        """
+        layer_sizes = self.rng.normal(
+            loc=self.nb_actors - self.std_nodes, scale=self.std_nodes, size=self.nb_layers
+        ).astype(int).clip(min=1, max=self.nb_actors)
+        return [ml.evolution_er(n=lv) for lv in layer_sizes]
+
+
+class MultilayerPAGenerator(MultilayerBaseGenerator):
+    """Class which generates multilayer network with Preferential Attachment algorithm."""
+    
+    def __init__(self, nb_layers: int, nb_actors: int, nb_steps: int, nb_hubs: int, random_state: int | None = None) -> None:
+        """
+        Initialise the object.
+
+        :param nb_layers: number of layers of the generated network
+        :param nb_actors: number of actors in the network
+        :param nb_steps: number of steps of the generative algorithm which builds the network
+        :param std_nodes: standard deviation of the number of nodes in each layer (expected value
+            is a number of actors)
+        :param random_state: RNG state to make the generation reproducible, defaults to None
+        """
+        super().__init__(
+            nb_layers=nb_layers,
+            nb_actors=nb_actors,
+            nb_steps=nb_steps,
+            random_state=random_state
+        )
+        self.nb_hubs = nb_hubs
+
+    def get_models(self) -> list[PyEvolutionModel]:
+        """
+        Get evolutionary models for each layer.
+
+        :return: list of Preferential Attachment generators
+        """
+        m0s = [self.nb_hubs] * self.nb_layers
+        ms = m0s.copy()
+        return [ml.evolution_pa(m0=m0, m=ms) for m0, ms in zip(m0s, ms)]
 
 
 def generate_multilayer(
@@ -46,7 +176,7 @@ def save_generate(
     ml.write(network, str(outfile))
 
 
-def parse_args() -> Namespace:
+def parse_args(args=None) -> Namespace:
     parser = ArgumentParser(
         description=__doc__,
         formatter_class=RawDescriptionHelpFormatter,
@@ -63,15 +193,14 @@ def parse_args() -> Namespace:
     parser.add_argument("--chunksize", type=int, default=1)
     parser.add_argument("--random-state", type=int, default=None)
 
-    return parser.parse_args()
+    return parser.parse_args(args)
 
 
 def main(args: Namespace):
+    print(args)
     rng = np.random.default_rng(args.random_state)
 
-    actors = np.arange(
-        args.min_actors, args.max_actors, args.step_size, dtype=np.int32
-    )
+    actors = np.arange(args.min_actors, args.max_actors, args.step_size, dtype=np.int32)
     layers = rng.integers(
         args.min_actors / 10,
         args.max_actors / 10,
@@ -103,7 +232,25 @@ def main(args: Namespace):
 
 
 def cli():
-    main(parse_args())
+    import network_diffusion as nd
+    args = parse_args(
+        [
+            "100",
+            "1000",
+            "--step-size", "1",
+            "--output-dir", "/Users/michal/Development/infmax-trainer-icm-mln/dupa",
+            "--n-jobs", "1",
+            "--chunksize", "1",
+            "--random-state", "1",
+        ]
+    )
+    # main(args)
+    net_uu = MultilayerERGenerator(nb_layers=3, nb_actors=30, nb_steps=40, std_nodes=14, random_state=43)()
+    # ml.plot(n=net_uu)
+    net_nx = ml.to_nx_dict(net_uu)
+    net_nd = nd.MultilayerNetwork(layers=net_nx)
+    nd.mln.functions.draw_mln(net_nd)
+    # print(network)
 
 
 if __name__ == "__main__":

--- a/nsl_data_utils/misc/generate.py
+++ b/nsl_data_utils/misc/generate.py
@@ -12,12 +12,12 @@ from tqdm.contrib.concurrent import process_map
 
 def generate_and_save(model_type: str, actors: int, layers: int, steps: int, outfile: str) -> None:
     """Generate network and save it as an mpx file."""
-    if model_type == "PA":
+    if model_type.upper() == "PA":
         nb_hubs = int(max(3, 0.05 * actors))
         generator = MultilayerPAGenerator(
             nb_layers=layers, nb_actors=actors, nb_steps=steps, nb_hubs=nb_hubs
         )
-    elif model_type == "ER":
+    elif model_type.upper() == "ER":
         std_nodes = int(0.1 * actors)
         generator = MultilayerERGenerator(
             nb_layers=layers, nb_actors=actors, nb_steps=steps, std_nodes=std_nodes
@@ -48,8 +48,18 @@ def parse_args(args=None) -> Namespace:
 
 def main(args: Namespace) -> None:
     """Main generation routine feed with CLI args."""
-    actors = np.random.randint(args.min_actors, args.max_actors + 1, dtype=np.int32, size=args.nb_networks)
-    layers = np.random.randint(args.min_layers, args.max_layers + 1, dtype=np.int32, size=args.nb_networks)
+    actors = np.random.randint(  # TODO: consider using a novel RNG numpy's policy!
+        args.min_actors,
+        args.max_actors + 1,
+        dtype=np.int32,
+        size=args.nb_networks,
+    )
+    layers = np.random.randint(
+        args.min_layers,
+        args.max_layers + 1,
+        dtype=np.int32,
+        size=args.nb_networks,
+    )
     steps = actors * 5
     output_dir = Path(args.output_dir)
     output_dir.mkdir(exist_ok=True, parents=True)
@@ -66,20 +76,8 @@ def main(args: Namespace) -> None:
     )
 
 
-def cli():
-    args = parse_args(
-        # [
-        #     "100",
-        #     "100",
-        #     "10000",
-        #     "2",
-        #     "5",
-        #     "ER",
-        #     "--output-dir", "krakrarkarka",
-        #     "--n-jobs", "5",
-        #     "--chunksize", "20"
-        # ]
-    )
+def cli() -> None:
+    args = parse_args()
     print(args)
     main(args)
 

--- a/nsl_data_utils/misc/generate.py
+++ b/nsl_data_utils/misc/generate.py
@@ -20,7 +20,7 @@ def generate_and_save(
 ) -> None:
     """Generate network and save it as an mpx file."""
     if model_type == "PA":
-        nb_hubs = np.array([0.05 * actors], dtype=np.int32).clip(min=3).item()
+        nb_hubs = int(max(3, 0.05 * actors))
         generator = MultilayerPAGenerator(
             nb_layers=layers,
             nb_actors=actors,
@@ -66,14 +66,14 @@ def main(args: Namespace) -> None:
     """Main generation routine feed with CLI args."""
 
     if args.random_state is not None:
-        np.random.seed(args.random_state)
+        np.random.seed(args.random_state)  # TODO!!!
 
     actors = np.random.randint(args.min_actors, args.max_actors + 1, dtype=np.int32, size=args.nb_networks)
     layers = np.random.randint(args.min_layers, args.max_layers + 1, dtype=np.int32, size=args.nb_networks)
     steps = actors * 5
     output_dir = Path(args.output_dir)
     output_dir.mkdir(exist_ok=True, parents=True)
-    outfiles = (output_dir / f"network_{a}.mpx" for a in actors)
+    outfiles = (output_dir / f"network_{idx}.mpx" for idx, _ in enumerate(actors, 1))
     random_states = (
         np.random.random(size=len(actors)) * 10 ** (np.log10(len(actors)) + 1)
     ).astype(np.int32)

--- a/nsl_data_utils/misc/generate.py
+++ b/nsl_data_utils/misc/generate.py
@@ -68,17 +68,17 @@ def main(args: Namespace) -> None:
 
 def cli():
     args = parse_args(
-        [
-            "100",
-            "100",
-            "10000",
-            "2",
-            "5",
-            "ER",
-            "--output-dir", "/Users/michal/Development/infmax-trainer-icm-mln/krakrarkarka",
-            "--n-jobs", "5",
-            "--chunksize", "20"
-        ]
+        # [
+        #     "100",
+        #     "100",
+        #     "10000",
+        #     "2",
+        #     "5",
+        #     "ER",
+        #     "--output-dir", "krakrarkarka",
+        #     "--n-jobs", "5",
+        #     "--chunksize", "20"
+        # ]
     )
     print(args)
     main(args)

--- a/nsl_data_utils/misc/generate.py
+++ b/nsl_data_utils/misc/generate.py
@@ -8,86 +8,81 @@ import uunet.multinet as ml
 
 from nsl_data_utils.misc.generators import MultilayerERGenerator, MultilayerPAGenerator
 from tqdm.contrib.concurrent import process_map
-from uunet._multinet import PyMLNetwork
 
 
-def generate_multilayer(
-    layers: int,
+def generate_and_save(
+    model_type: str,
     actors: int,
-    steps: int,
-    random_state: int | None = None,
-) -> PyMLNetwork:
-    rng = np.random.default_rng(random_state)
-
-    models = [
-        ml.evolution_er(n)
-        for n in rng.integers(actors / 10, actors, size=layers)
-    ]
-    pr_internal = rng.uniform(0, 1, size=layers).tolist()
-    pr_external = rng.uniform(0, 1, size=layers).tolist()
-
-    dependency = np.full(
-        fill_value=1 / layers, shape=(layers, layers)
-    ).tolist()
-
-    return ml.grow(actors, steps, models, pr_internal, pr_external, dependency)
-
-
-def save_generate(
     layers: int,
-    actors: int,
     steps: int,
     outfile: str,
     random_state: int | None = None,
 ) -> None:
-    network = generate_multilayer(
-        layers=layers, actors=actors, steps=steps, random_state=random_state
-    )
+    """Generate network and save it as an mpx file."""
+    if model_type == "PA":
+        nb_hubs = np.array([0.05 * actors], dtype=np.int32).clip(min=3).item()
+        generator = MultilayerPAGenerator(
+            nb_layers=layers,
+            nb_actors=actors,
+            nb_steps=steps,
+            nb_hubs=nb_hubs,
+            random_state=random_state,
+        )
+    elif model_type == "ER":
+        std_nodes = int(0.1 * actors)
+        generator = MultilayerERGenerator(
+            nb_layers=layers,
+            nb_actors=actors,
+            nb_steps=steps,
+            std_nodes=std_nodes,
+            random_state=random_state,
+        )
+    else:
+        raise ValueError("Model type can be either PA or ER!")
+    network = generator()
     ml.write(network, str(outfile))
 
 
 def parse_args(args=None) -> Namespace:
-    """Parse CLI args accorfding to the parser."""
+    """Parse CLI args according to the parser."""
     parser = ArgumentParser(
         description=__doc__,
         formatter_class=RawDescriptionHelpFormatter,
     )
+    parser.add_argument("nb_networks", type=int)
     parser.add_argument("min_actors", type=int)
     parser.add_argument("max_actors", type=int)
-    parser.add_argument("-s", "--step-size", type=int, default=1)
-    parser.add_argument("-o", "--output-dir", type=str, default="./generated_graphs/")
-    parser.add_argument("--n-jobs", type=int, default=None)
-    parser.add_argument("--chunksize", type=int, default=1)
+    parser.add_argument("min_layers", type=int)
+    parser.add_argument("max_layers", type=int)
+    parser.add_argument("model_type", type=str, choices=["ER", "PA"])
     parser.add_argument("--random-state", type=int, default=None)
+    parser.add_argument("-o", "--output-dir", type=str, default="./generated_graphs/")
+    parser.add_argument("--n-jobs", type=int, default=1)
+    parser.add_argument("--chunksize", type=int, default=1)
     return parser.parse_args(args)
 
 
 def main(args: Namespace) -> None:
-    rng = np.random.default_rng(args.random_state)
+    """Main generation routine feed with CLI args."""
 
-    actors = np.arange(args.min_actors, args.max_actors, args.step_size, dtype=np.int32)
-    layers = rng.integers(
-        args.min_actors / 10,
-        args.max_actors / 10,
-        size=len(actors),
-        dtype=np.int32,
-    )
+    if args.random_state is not None:
+        np.random.seed(args.random_state)
+
+    actors = np.random.randint(args.min_actors, args.max_actors + 1, dtype=np.int32, size=args.nb_networks)
+    layers = np.random.randint(args.min_layers, args.max_layers + 1, dtype=np.int32, size=args.nb_networks)
     steps = actors * 5
-
-    random_states = rng.integers(
-        np.iinfo(np.int32).max - 1,
-        size=len(actors),
-        dtype=np.int32,
-    )
-
     output_dir = Path(args.output_dir)
     output_dir.mkdir(exist_ok=True, parents=True)
     outfiles = (output_dir / f"network_{a}.mpx" for a in actors)
+    random_states = (
+        np.random.random(size=len(actors)) * 10 ** (np.log10(len(actors)) + 1)
+    ).astype(np.int32)
 
     process_map(
-        save_generate,
-        layers,
+        generate_and_save,
+        [args.model_type] * len(actors),
         actors,
+        layers,
         steps,
         outfiles,
         random_states,
@@ -100,10 +95,13 @@ def cli():
     args = parse_args(
         [
             "100",
-            "1000",
-            "--step-size", "1",
-            "--output-dir", "/Users/michal/Development/infmax-trainer-icm-mln/dupa",
-            "--n-jobs", "1",
+            "100",
+            "10000",
+            "2",
+            "5",
+            "ER",
+            "--output-dir", "/Users/michal/Development/infmax-trainer-icm-mln/krakrarkarka",
+            "--n-jobs", "10",
             "--chunksize", "1",
             "--random-state", "1",
         ]

--- a/nsl_data_utils/misc/generators.py
+++ b/nsl_data_utils/misc/generators.py
@@ -89,7 +89,7 @@ class MultilayerERGenerator(MultilayerBaseGenerator):
         """
         layer_sizes = np.random.normal(
             loc=self.nb_actors - self.std_nodes, scale=self.std_nodes, size=self.nb_layers
-        ).astype(int).clip(min=1, max=self.nb_actors)
+        ).astype(np.int32).clip(min=1, max=self.nb_actors)
         return [ml.evolution_er(n=lv) for lv in layer_sizes]
 
 

--- a/nsl_data_utils/misc/generators.py
+++ b/nsl_data_utils/misc/generators.py
@@ -13,21 +13,17 @@ class MultilayerBaseGenerator(abc.ABC):
     """Abstract base class for multilayer network generators."""
 
     @abc.abstractmethod
-    def __init__(
-        self, nb_layers: int, nb_actors: int, nb_steps: int, random_state: int | None = None,
-    ) -> None:
+    def __init__(self, nb_layers: int, nb_actors: int, nb_steps: int) -> None:
         """
         Initialise the object.
 
         :param nb_layers: number of layers of the generated network
         :param nb_actors: number of actors in the network
         :param nb_steps: number of steps of the generative algorithm which builds the network
-        :param random_state: RNG state to make the generation reproducible, defaults to None
         """
         self.nb_layers=nb_layers
         self.nb_actors=nb_actors
         self.nb_steps=nb_steps
-        self.rng = np.random.default_rng(random_state)
 
     @abc.abstractmethod
     def get_models(self) -> list[PyEvolutionModel]:
@@ -55,7 +51,7 @@ class MultilayerBaseGenerator(abc.ABC):
         :return: generated network as a PyEvolutionModel object
         """
         models = self.get_models()
-        pr_internal = self.rng.uniform(0, 1, size=self.nb_layers)
+        pr_internal = np.random.uniform(0, 1, size=self.nb_layers)
         pr_external = np.ones_like(pr_internal) - pr_internal  # TODO: there is no noaction step now!
         dependency = self.get_dependency()
         return ml.grow(
@@ -71,14 +67,7 @@ class MultilayerBaseGenerator(abc.ABC):
 class MultilayerERGenerator(MultilayerBaseGenerator):
     """Class which generates multilayer network with Erdos-Renyi algorithm."""
     
-    def __init__(
-        self,
-        nb_layers: int,
-        nb_actors: int,
-        nb_steps: int,
-        std_nodes: int,
-        random_state: int | None = None
-    ) -> None:
+    def __init__(self, nb_layers: int, nb_actors: int, nb_steps: int, std_nodes: int) -> None:
         """
         Initialise the object.
 
@@ -87,14 +76,8 @@ class MultilayerERGenerator(MultilayerBaseGenerator):
         :param nb_steps: number of steps of the generative algorithm which builds the network
         :param std_nodes: standard deviation of the number of nodes in each layer (expected value
             is a number of actors)
-        :param random_state: RNG state to make the generation reproducible, defaults to None
         """
-        super().__init__(
-            nb_layers=nb_layers,
-            nb_actors=nb_actors,
-            nb_steps=nb_steps,
-            random_state=random_state
-        )
+        super().__init__(nb_layers=nb_layers, nb_actors=nb_actors, nb_steps=nb_steps)
         assert nb_actors - 2 * std_nodes > 0, "Number of actors shall be g.t. 2 * std_nodes"
         self.std_nodes=std_nodes
 
@@ -104,7 +87,7 @@ class MultilayerERGenerator(MultilayerBaseGenerator):
 
         :return: list of Erdos-Renyi generators
         """
-        layer_sizes = self.rng.normal(
+        layer_sizes = np.random.normal(
             loc=self.nb_actors - self.std_nodes, scale=self.std_nodes, size=self.nb_layers
         ).astype(int).clip(min=1, max=self.nb_actors)
         return [ml.evolution_er(n=lv) for lv in layer_sizes]
@@ -113,14 +96,7 @@ class MultilayerERGenerator(MultilayerBaseGenerator):
 class MultilayerPAGenerator(MultilayerBaseGenerator):
     """Class which generates multilayer network with Preferential Attachment algorithm."""
     
-    def __init__(
-        self,
-        nb_layers: int,
-        nb_actors: int,
-        nb_steps: int,
-        nb_hubs: int,
-        random_state: int | None = None
-    ) -> None:
+    def __init__(self, nb_layers: int, nb_actors: int, nb_steps: int, nb_hubs: int) -> None:
         """
         Initialise the object.
 
@@ -128,14 +104,8 @@ class MultilayerPAGenerator(MultilayerBaseGenerator):
         :param nb_actors: number of actors in the network
         :param nb_steps: number of steps of the generative algorithm which builds the network
         :param nb_seeds: number of seeds in each layer and a number of egdes from each new vertex
-        :param random_state: RNG state to make the generation reproducible, defaults to None
         """
-        super().__init__(
-            nb_layers=nb_layers,
-            nb_actors=nb_actors,
-            nb_steps=nb_steps,
-            random_state=random_state
-        )
+        super().__init__(nb_layers=nb_layers, nb_actors=nb_actors, nb_steps=nb_steps)
         self.nb_hubs = nb_hubs
 
     def get_models(self) -> list[PyEvolutionModel]:
@@ -156,13 +126,9 @@ def dry_run(model: Literal["PA", "ER"]) -> None:
     import network_diffusion as nd
 
     if model == "ER":
-        net_uu = MultilayerERGenerator(
-            nb_layers=3, nb_actors=300, nb_steps=400, std_nodes=30, random_state=43
-        )()
+        net_uu = MultilayerERGenerator(nb_layers=3, nb_actors=300, nb_steps=400, std_nodes=30)()
     elif model == "PA":
-        net_uu = MultilayerPAGenerator(
-            nb_layers=3, nb_actors=1000, nb_steps=1000, nb_hubs=3, random_state=43
-        )()
+        net_uu = MultilayerPAGenerator(nb_layers=3, nb_actors=1000, nb_steps=1000, nb_hubs=3)()
     else:
         raise ValueError("Incorret model name!")
     print(net_uu)

--- a/nsl_data_utils/misc/generators.py
+++ b/nsl_data_utils/misc/generators.py
@@ -1,0 +1,186 @@
+"""Generators of multilayer networks with Preferential Attachment or Erdos-Renyi models."""
+
+import abc
+from typing import Literal
+
+import numpy as np
+import uunet.multinet as ml
+
+from uunet._multinet import PyMLNetwork, PyEvolutionModel
+
+
+class MultilayerBaseGenerator(abc.ABC):
+    """Abstract base class for multilayer network generators."""
+
+    @abc.abstractmethod
+    def __init__(
+        self, nb_layers: int, nb_actors: int, nb_steps: int, random_state: int | None = None,
+    ) -> None:
+        """
+        Initialise the object.
+
+        :param nb_layers: number of layers of the generated network
+        :param nb_actors: number of actors in the network
+        :param nb_steps: number of steps of the generative algorithm which builds the network
+        :param random_state: RNG state to make the generation reproducible, defaults to None
+        """
+        self.nb_layers=nb_layers
+        self.nb_actors=nb_actors
+        self.nb_steps=nb_steps
+        self.rng = np.random.default_rng(random_state)
+
+    @abc.abstractmethod
+    def get_models(self) -> list[PyEvolutionModel]:
+        """
+        Get evolutionary models for each layer.
+
+        :return: list of concrete network generators
+        """
+        pass
+
+    def get_dependency(self) -> np.ndarray:
+        """
+        Create a dependency matrix for the network generator.
+
+        :return: matrix shaped: [nb_layers, nb_layers] with 0s in diagonal and 1/nb_layers otherwise
+        """
+        dep = np.full(fill_value=(1 / self.nb_layers), shape=(self.nb_layers, self.nb_layers))
+        np.fill_diagonal(dep, 0)
+        return dep
+
+    def __call__(self) -> PyMLNetwork:
+        """
+        Generate the network according to given parameters.
+
+        :return: generated network as a PyEvolutionModel object
+        """
+        models = self.get_models()
+        pr_internal = self.rng.uniform(0, 1, size=self.nb_layers)
+        pr_external = np.ones_like(pr_internal) - pr_internal  # TODO: there is no noaction step now!
+        dependency = self.get_dependency()
+        return ml.grow(
+            self.nb_actors,
+            self.nb_steps,
+            models,
+            pr_internal.tolist(),
+            pr_external.tolist(),
+            dependency.tolist(),
+        )
+
+
+class MultilayerERGenerator(MultilayerBaseGenerator):
+    """Class which generates multilayer network with Erdos-Renyi algorithm."""
+    
+    def __init__(
+        self,
+        nb_layers: int,
+        nb_actors: int,
+        nb_steps: int,
+        std_nodes: int,
+        random_state: int | None = None
+    ) -> None:
+        """
+        Initialise the object.
+
+        :param nb_layers: number of layers of the generated network
+        :param nb_actors: number of actors in the network
+        :param nb_steps: number of steps of the generative algorithm which builds the network
+        :param std_nodes: standard deviation of the number of nodes in each layer (expected value
+            is a number of actors)
+        :param random_state: RNG state to make the generation reproducible, defaults to None
+        """
+        super().__init__(
+            nb_layers=nb_layers,
+            nb_actors=nb_actors,
+            nb_steps=nb_steps,
+            random_state=random_state
+        )
+        assert nb_actors - 2 * std_nodes > 0, "Number of actors shall be g.t. 2 * std_nodes"
+        self.std_nodes=std_nodes
+
+    def get_models(self) -> list[PyEvolutionModel]:
+        """
+        Get evolutionary models for each layer with num nodes drawn from a standard distribution.
+
+        :return: list of Erdos-Renyi generators
+        """
+        layer_sizes = self.rng.normal(
+            loc=self.nb_actors - self.std_nodes, scale=self.std_nodes, size=self.nb_layers
+        ).astype(int).clip(min=1, max=self.nb_actors)
+        return [ml.evolution_er(n=lv) for lv in layer_sizes]
+
+
+class MultilayerPAGenerator(MultilayerBaseGenerator):
+    """Class which generates multilayer network with Preferential Attachment algorithm."""
+    
+    def __init__(
+        self,
+        nb_layers: int,
+        nb_actors: int,
+        nb_steps: int,
+        nb_hubs: int,
+        random_state: int | None = None
+    ) -> None:
+        """
+        Initialise the object.
+
+        :param nb_layers: number of layers of the generated network
+        :param nb_actors: number of actors in the network
+        :param nb_steps: number of steps of the generative algorithm which builds the network
+        :param nb_seeds: number of seeds in each layer and a number of egdes from each new vertex
+        :param random_state: RNG state to make the generation reproducible, defaults to None
+        """
+        super().__init__(
+            nb_layers=nb_layers,
+            nb_actors=nb_actors,
+            nb_steps=nb_steps,
+            random_state=random_state
+        )
+        self.nb_hubs = nb_hubs
+
+    def get_models(self) -> list[PyEvolutionModel]:
+        """
+        Get evolutionary models for each layer.
+
+        :return: list of Preferential Attachment generators
+        """
+        m0s = [self.nb_hubs] * self.nb_layers
+        ms = m0s.copy()
+        return [ml.evolution_pa(m0=m0, m=ms) for m0, ms in zip(m0s, ms)]
+    
+
+def dry_run(model: Literal["PA", "ER"]) -> None:
+    """Test if calling generators returns reasonable results."""
+    import matplotlib.pyplot as plt
+    import networkx as nx
+    import network_diffusion as nd
+
+    if model == "ER":
+        net_uu = MultilayerERGenerator(
+            nb_layers=3, nb_actors=300, nb_steps=400, std_nodes=30, random_state=43
+        )()
+    elif model == "PA":
+        net_uu = MultilayerPAGenerator(
+            nb_layers=3, nb_actors=1000, nb_steps=1000, nb_hubs=3, random_state=43
+        )()
+    else:
+        raise ValueError("Incorret model name!")
+    print(net_uu)
+
+    net_nx = ml.to_nx_dict(net_uu)
+    print(net_nx)
+
+    net_nd = nd.MultilayerNetwork(layers=net_nx)
+    print(net_nd)
+
+    fig, axs = plt.subplots(nrows=1, ncols=len(net_nx))
+    for l_idx, (l_name, l_graph) in enumerate(net_nx.items()):
+        axs[l_idx].hist(nx.degree_histogram(l_graph), bins=10)
+        axs[l_idx].set_title(l_name)
+    fig.suptitle("Degree distribution")
+    plt.show()
+
+
+if __name__ == "__main__":
+    dry_run("ER")
+    dry_run("PA")


### PR DESCRIPTION
I've modified @adampirog 's proposal so that it can handle more models and it meets our requirements better. Here are main changes:
- I've implemented a Preferential Attachment model (which can be considered as a sibling of the Barabasi-Albert model)
- I've designed an abstraction over PA and ER models following OOP paradigm
- I've adjusted CLI configuration so that we only have to provide: number of networks to generate, min and max numbers of actors and layers, network model type to harness
- ER model selects number of nodes in each layer following Gaussian distribution with: expected value equals number of actors and with standard deviation equals 10% of the former
- PA model picks `m0` (aka number of hubs) and `m`(aka number of links to attach with for each new node) as follows: `m0` is 5% of given number of actors (but not less than 3) and `m=`m0`
- since fixing RNG didn't result for me in reproducible results, I've removed it


To test the code please run:
- `nsl_data_utils/misc/generators.py` to see degree distributions of one network generated with each model
- `nsl_data_utils/misc/generatore.py` and uncomment lines 71-81 to see a demo of the main routine



